### PR TITLE
Allow configuration of controller namespaces

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -3,14 +3,14 @@
 use Pvtl\VoyagerFrontend\Page;
 use Illuminate\Support\Facades\Request;
 
-$accountController = '\Pvtl\VoyagerFrontend\Http\Controllers\AccountController';
-$searchController = '\Pvtl\VoyagerFrontend\Http\Controllers\SearchController';
+$accountController = config('voyager-frontend.controllers.account', '\Pvtl\VoyagerFrontend\Http\Controllers\AccountController');
+$searchController = config('voyager-frontend.controllers.search',  '\Pvtl\VoyagerFrontend\Http\Controllers\SearchController');
 
 /**
  * Authentication
  */
 Route::group(['middleware' => ['web']], function () use ($accountController) {
-    Route::group(['namespace' => 'App\Http\Controllers'], function () {
+    Route::group(['namespace' => config('voyager-frontend.controllers.auth_namespace', 'App\Http\Controllers')], function () {
         Auth::routes();
     });
 
@@ -35,7 +35,7 @@ Route::group([
     'as' => 'voyager-frontend.pages.',
     'prefix' => 'admin/pages/',
     'middleware' => ['web', 'admin.user'],
-    'namespace' => '\Pvtl\VoyagerFrontend\Http\Controllers'
+    'namespace' => config('voyager-frontend.controllers.namespace', '\Pvtl\VoyagerFrontend\Http\Controllers')
 ], function () {
     Route::post('layout/{id?}', ['uses' => "PageController@changeLayout", 'as' => 'layout']);
 });


### PR DESCRIPTION
This adds four new config variables:
voyager-frontend.controllers.account
voyager-frontend.controllers.search
voyager-frontend.controllers.namespace
voyager-frontend.controllers.auth-namespace

These can be used to override the default controllers that come with this package. This is useful in case an application doesn't use the default App namespace